### PR TITLE
Add top margin into position calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ AndroidSlidingDownPanel
 =======================
 SlidingDownPanel provides a vertical, multi-pane layout for user at the top level of a UI, just like the usage in [Aviate](http://getaviate.com/).
 
+![Panel up](http://i.imgur.com/yvvTYnvl.png "Panel up")
+![Panel down](http://i.imgur.com/SvrCw7nl.png "Panel slided down")
+
 Usage
 =====
 The layout could be usage as [SlidingPaneLayout]( http://developer.android.com/reference/android/support/v4/widget/SlidingPaneLayout.html). To use of the layout, simply include `com.argonware.slidingdownpanel.SlidingDownPanelLayout` as the root element for your multi pane layout. Add two children view. The first child is your main layout. The second child is your layout for the sliding down panel. 

--- a/library/src/com/argonware/slidingdownpanel/SlidingDownPanelLayout.java
+++ b/library/src/com/argonware/slidingdownpanel/SlidingDownPanelLayout.java
@@ -624,8 +624,8 @@ public class SlidingDownPanelLayout extends ViewGroup {
 
             if (lp.slideable) {
                 final int margin = lp.leftMargin + lp.rightMargin;
-                final int range = Math.min(nextYStart,
-                        height - paddingBottom - mOverhangSize - yStart - margin);
+                final int range = Math.max(0, Math.min(nextYStart,
+                    height - paddingBottom - mOverhangSize - yStart - margin - lp.topMargin));
                 mSlideRange = range;
                 lp.dimWhenOffset = yStart + lp.topMargin + range + childHeight / 2 >
                         height - paddingBottom;


### PR DESCRIPTION
Top margin of the panel is considered when calculating the down
position for the panel so it doesn’t fall of the screen.
Without this, when the panel has a top margin and it is pulled down, it is rendered useless since it cannot be pulled up anymore.
